### PR TITLE
Use pyserini's new prebuilt index features

### DIFF
--- a/bertserini/retriever/pyserini_retriever.py
+++ b/bertserini/retriever/pyserini_retriever.py
@@ -13,6 +13,11 @@ def build_searcher(index_path, k1=0.9, b=0.4, language="en"):
     searcher.object.setLanguage(language)
     return searcher
 
+def build_searcher_from_prebuilt_index(index_name, k1=0.9, b=0.4, language="en"):
+    searcher = SimpleSearcher.from_prebuilt_index(index_name)
+    searcher.set_bm25(k1, b)
+    searcher.object.setLanguage(language)
+    return searcher
 
 def retriever(question, searcher, para_num=20):
     language = question.language


### PR DESCRIPTION
I tested with the **Development Installation** of pyserini. 
(pyserini's current PyPI version doesn't support prebuilt index)
This modification can take advantage of pyserini's new prebuilt index features, but we need to merge this PR(https://github.com/castorini/pyserini/pull/235) first. Then I can add information about `lucene-index.enwiki-20180701-paragraphs.tar.gz` and `https://www.dropbox.com/s/6zn16mombt0wirs/lucene-index.zhwiki-20181201-paragraphs.tar.gz?dl=0` in pyserini.


